### PR TITLE
Update app_timer.cpp

### DIFF
--- a/main/apps/app_timer/app_timer.cpp
+++ b/main/apps/app_timer/app_timer.cpp
@@ -68,7 +68,7 @@ void AppTimer::onRunning()
             _data.hal->canvas()->setTextSize(1);
             _data.hal->canvas()->print("System Time");
 
-            snprintf(_data.string_buffer, sizeof(_data.string_buffer), "%02lld:%02lld:%02lld", millis() / 3600000, millis() / 60000, (millis() / 1000) % 60);
+            snprintf(_data.string_buffer, sizeof(_data.string_buffer), "%02lld:%02lld:%02lld", millis() / 3600000, (millis() / 60000) % 60, (millis() / 1000) % 60);
             
             _data.hal->canvas()->setTextSize(2);
             _data.hal->canvas()->drawCenterString(_data.string_buffer, _data.hal->canvas()->width() / 2, _data.hal->canvas()->height() / 2 - 10);

--- a/main/apps/app_timer/app_timer.cpp
+++ b/main/apps/app_timer/app_timer.cpp
@@ -68,7 +68,7 @@ void AppTimer::onRunning()
             _data.hal->canvas()->setTextSize(1);
             _data.hal->canvas()->print("System Time");
 
-            snprintf(_data.string_buffer, sizeof(_data.string_buffer), "%02lld:%02lld:%02lld", millis() / 3600000, (millis() / 60000) % 60, (millis() / 1000) % 60);
+            snprintf(_data.string_buffer, sizeof(_data.string_buffer), "%02lld:%02lld:%02lld", (millis() / 3600000) % 60, (millis() / 60000) % 60, (millis() / 1000) % 60);
             
             _data.hal->canvas()->setTextSize(2);
             _data.hal->canvas()->drawCenterString(_data.string_buffer, _data.hal->canvas()->width() / 2, _data.hal->canvas()->height() / 2 - 10);

--- a/main/apps/launcher/port/port.cpp
+++ b/main/apps/launcher/port/port.cpp
@@ -255,7 +255,7 @@ void Launcher::_port_update_system_state()
     else 
     {
         // Fake time 
-        snprintf(_data.string_buffer, sizeof(_data.string_buffer), "%02lld:%02lld", millis() / 3600000, millis() / 60000);
+        snprintf(_data.string_buffer, sizeof(_data.string_buffer), "%02lld:%02lld", millis() / 3600000, (millis() / 60000) % 60)
     }
     _data.system_state.time = _data.string_buffer;
     // spdlog::info("time: {}", _data.system_state.time);

--- a/main/apps/launcher/port/port.cpp
+++ b/main/apps/launcher/port/port.cpp
@@ -255,7 +255,7 @@ void Launcher::_port_update_system_state()
     else 
     {
         // Fake time 
-        snprintf(_data.string_buffer, sizeof(_data.string_buffer), "%02lld:%02lld", millis() / 3600000, (millis() / 60000) % 60)
+        snprintf(_data.string_buffer, sizeof(_data.string_buffer), "%02lld:%02lld", (millis() / 3600000) % 60, (millis() / 60000) % 60)
     }
     _data.system_state.time = _data.string_buffer;
     // spdlog::info("time: {}", _data.system_state.time);


### PR DESCRIPTION
The calculation for minutes does not reset when it reaches its maximum value (60 minutes in an hour). Added code to ensure minutes resets to 0 after 59.