### PR TITLE
Various improvements to Keyboard usage

### DIFF
--- a/main/apps/app_launcher/app_launcher.h
+++ b/main/apps/app_launcher/app_launcher.h
@@ -19,19 +19,19 @@
 class Launcher : public mooncake::AppAbility {
 private:
     struct KeyboardBarState_t {
-        bool caps_lock = false;
-        bool fn        = false;
-        bool ctrl      = false;
-        bool opt       = false;
-        bool alt       = false;
+        bool shift = false;
+        bool fn    = false;
+        bool ctrl  = false;
+        bool opt   = false;
+        bool alt   = false;
 
         void reset()
         {
-            caps_lock = false;
-            fn        = false;
-            ctrl      = false;
-            opt       = false;
-            alt       = false;
+            shift = false;
+            fn    = false;
+            ctrl  = false;
+            opt   = false;
+            alt   = false;
         }
     };
 

--- a/main/apps/app_launcher/view/keyboard_bar/keyboard_bar.cpp
+++ b/main/apps/app_launcher/view/keyboard_bar/keyboard_bar.cpp
@@ -38,7 +38,7 @@ void Launcher::render_keyboard_bar()
     int height = 17;
     int gap_y  = 3;
 
-    if (_data.keyboard_state.caps_lock) {
+    if (_data.keyboard_state.shift) {
         GetHAL().canvasKeyboardBar.pushImage(x, y, width, height, image_data_Aa);
     } else {
         GetHAL().canvasKeyboardBar.pushImage(x, y, width, height, image_data_Aa0);
@@ -80,29 +80,31 @@ void Launcher::start_keyboard_bar()
 {
     GetHAL().keyboard.onKeyEvent.connect([this](const Keyboard::KeyEvent_t& keyEvent) {
         bool need_render = false;
-        switch (keyEvent.keyCode) {
-            case KEY_CAPSLOCK:
-                _data.keyboard_state.caps_lock = keyEvent.state;
-                need_render                    = true;
-                break;
-            case KEY_LEFTCTRL:
-                _data.keyboard_state.ctrl = keyEvent.state;
-                need_render               = true;
-                break;
-            case KEY_LEFTMETA:
-                _data.keyboard_state.opt = keyEvent.state;
-                need_render              = true;
-                break;
-            case KEY_LEFTALT:
-                _data.keyboard_state.alt = keyEvent.state;
-                need_render              = true;
-                break;
-            case KEY_LEFTSHIFT:
-                _data.keyboard_state.fn = keyEvent.state;
-                need_render             = true;
-                break;
-            default:
-                break;
+        // Fn key emits KEY_NONE with isModifier - handle before the switch
+        if (keyEvent.keyCode == KEY_NONE && keyEvent.isModifier) {
+            _data.keyboard_state.fn = keyEvent.state;
+            need_render             = true;
+        } else {
+            switch (keyEvent.keyCode) {
+                case KEY_LEFTSHIFT:
+                    _data.keyboard_state.shift = keyEvent.state;
+                    need_render                = true;
+                    break;
+                case KEY_LEFTCTRL:
+                    _data.keyboard_state.ctrl = keyEvent.state;
+                    need_render               = true;
+                    break;
+                case KEY_LEFTMETA:
+                    _data.keyboard_state.opt = keyEvent.state;
+                    need_render              = true;
+                    break;
+                case KEY_LEFTALT:
+                    _data.keyboard_state.alt = keyEvent.state;
+                    need_render              = true;
+                    break;
+                default:
+                    break;
+            }
         }
 
         if (need_render) {

--- a/main/hal/hal.cpp
+++ b/main/hal/hal.cpp
@@ -569,8 +569,8 @@ void Hal::handle_ble_keyboard_event(const Keyboard::KeyEvent_t& keyEvent)
         // Get current modifier state from keyboard
         uint8_t modifierMask = keyboard.getModifierMask();
 
-        // Set modifier byte
-        buffer[0] = modifierMask;
+        // Set modifier byte (physical modifiers + any firmware-injected ones, e.g. Fn+alpha -> LSHIFT)
+        buffer[0] = modifierMask | keyEvent.extraModifiers;
 
         // For modifier keys themselves, don't set keycode
         if (keyEvent.isModifier) {
@@ -641,8 +641,9 @@ void Hal::handle_usb_keyboard_event(const Keyboard::KeyEvent_t& keyEvent)
 
     // Handle key press/release
     if (keyEvent.state) {
+        uint8_t mod = GetHAL().keyboard.getModifierMask() | keyEvent.extraModifiers;
         uint8_t keycode[6] = {keyEvent.keyCode};
-        tusb_hid_device_helper_report(GetHAL().keyboard.getModifierMask(), keycode);
+        tusb_hid_device_helper_report(mod, keycode);
         mclog::tagDebug(_tag, "usb keyboard sent key: {} (code: {})", keyEvent.keyName ? keyEvent.keyName : "special",
                         (int)keyEvent.keyCode);
     } else {

--- a/main/hal/hal.cpp
+++ b/main/hal/hal.cpp
@@ -581,20 +581,14 @@ void Hal::handle_ble_keyboard_event(const Keyboard::KeyEvent_t& keyEvent)
 
         // Send key press
         ble_hid_device_helper_send(buffer);
-        mclog::tagDebug(_tag, "ble keyboard sent key: {} (code: {}, modifier: 0x{:02x})",
+        mclog::tagDebug(_tag, "ble keyboard sent key: {} (code: {}, modifier: {:08b})",
                         keyEvent.keyName ? keyEvent.keyName : "special", (int)keyEvent.keyCode, modifierMask);
     } else {
-        // Key released - for modifier keys, update modifier state and send
-        if (keyEvent.isModifier) {
-            uint8_t modifierMask = keyboard.getModifierMask();
-            buffer[0]            = modifierMask;
-            buffer[2]            = 0;
-        } else {
-            // For non-modifier keys, send empty buffer (all keys up)
-            memset(buffer, 0, sizeof(buffer));
-        }
+        // Key released - always preserve current modifier state so held modifiers (e.g. ALT) stay active
+        buffer[0] = keyboard.getModifierMask();
+        buffer[2] = 0;
         ble_hid_device_helper_send(buffer);
-        mclog::tagDebug(_tag, "ble keyboard key released");
+        mclog::tagDebug(_tag, "ble keyboard key released (modifier: {:08b})", buffer[0]);
     }
 }
 
@@ -642,12 +636,16 @@ void Hal::handle_usb_keyboard_event(const Keyboard::KeyEvent_t& keyEvent)
     // Handle key press/release
     if (keyEvent.state) {
         uint8_t mod = GetHAL().keyboard.getModifierMask() | keyEvent.extraModifiers;
-        uint8_t keycode[6] = {keyEvent.keyCode};
-        tusb_hid_device_helper_report(mod, keycode);
-        mclog::tagDebug(_tag, "usb keyboard sent key: {} (code: {})", keyEvent.keyName ? keyEvent.keyName : "special",
-                        (int)keyEvent.keyCode);
+        if (keyEvent.isModifier) {
+            tusb_hid_device_helper_report(mod, NULL);
+        } else {
+            uint8_t keycode[6] = {keyEvent.keyCode};
+            tusb_hid_device_helper_report(mod, keycode);
+        }
+        mclog::tagDebug(_tag, "usb keyboard sent key: {} (code: {}, modifier: {:08b})",
+                        keyEvent.keyName ? keyEvent.keyName : "special", (int)keyEvent.keyCode, mod);
     } else {
-        tusb_hid_device_helper_report(0, NULL);
+        tusb_hid_device_helper_report(GetHAL().keyboard.getModifierMask(), NULL);
         mclog::tagDebug(_tag, "usb keyboard key released");
     }
 }

--- a/main/hal/keyboard/keyboard.cpp
+++ b/main/hal/keyboard/keyboard.cpp
@@ -133,68 +133,78 @@ void Keyboard::update_modifier_mask(const KeyEventRaw_t& key)
 }
 
 struct KeyValue_t {
-    const char* firstName;
+    const char*        firstName;
     const KeScanCode_t firstKeyCode;
-    const char* secondName;
+    const char*        secondName;
     const KeScanCode_t secondKeyCode;
+    const char*        fnName;           // nullptr = no Fn override
+    const KeScanCode_t fnKeyCode;        // KEY_NONE = no Fn override
+    const uint8_t      fnExtraModifiers; // extra HID modifier bits injected for this Fn key
 };
 
-const KeyValue_t _key_value_map[4][14] = {{{"`", KEY_GRAVE, "~", KEY_GRAVE},
-                                           {"1", KEY_1, "!", KEY_1},
-                                           {"2", KEY_2, "@", KEY_2},
-                                           {"3", KEY_3, "#", KEY_3},
-                                           {"4", KEY_4, "$", KEY_4},
-                                           {"5", KEY_5, "%", KEY_5},
-                                           {"6", KEY_6, "^", KEY_6},
-                                           {"7", KEY_7, "&", KEY_7},
-                                           {"8", KEY_8, "*", KEY_8},
-                                           {"9", KEY_9, "(", KEY_9},
-                                           {"0", KEY_0, ")", KEY_0},
-                                           {"-", KEY_MINUS, "_", KEY_MINUS},
-                                           {"=", KEY_EQUAL, "+", KEY_EQUAL},
-                                           {"del", KEY_BACKSPACE, "del", KEY_BACKSPACE}},
-                                          {{"tab", KEY_TAB, "tab", KEY_TAB},
-                                           {"q", KEY_Q, "Q", KEY_Q},
-                                           {"w", KEY_W, "W", KEY_W},
-                                           {"e", KEY_E, "E", KEY_E},
-                                           {"r", KEY_R, "R", KEY_R},
-                                           {"t", KEY_T, "T", KEY_T},
-                                           {"y", KEY_Y, "Y", KEY_Y},
-                                           {"u", KEY_U, "U", KEY_U},
-                                           {"i", KEY_I, "I", KEY_I},
-                                           {"o", KEY_O, "O", KEY_O},
-                                           {"p", KEY_P, "P", KEY_P},
-                                           {"[", KEY_LEFTBRACE, "{", KEY_LEFTBRACE},
-                                           {"]", KEY_RIGHTBRACE, "}", KEY_RIGHTBRACE},
-                                           {"\\", KEY_BACKSLASH, "|", KEY_BACKSLASH}},
-                                          {{"fn", KEY_NONE, "fn", KEY_NONE},
-                                           {"shift", KEY_LEFTSHIFT, "shift", KEY_LEFTSHIFT},
-                                           {"a", KEY_A, "A", KEY_A},
-                                           {"s", KEY_S, "S", KEY_S},
-                                           {"d", KEY_D, "D", KEY_D},
-                                           {"f", KEY_F, "F", KEY_F},
-                                           {"g", KEY_G, "G", KEY_G},
-                                           {"h", KEY_H, "H", KEY_H},
-                                           {"j", KEY_J, "J", KEY_J},
-                                           {"k", KEY_K, "K", KEY_K},
-                                           {"l", KEY_L, "L", KEY_L},
-                                           {";", KEY_SEMICOLON, ":", KEY_SEMICOLON},
-                                           {"'", KEY_APOSTROPHE, "\"", KEY_APOSTROPHE},
-                                           {"enter", KEY_ENTER, "enter", KEY_ENTER}},
-                                          {{"ctrl", KEY_LEFTCTRL, "ctrl", KEY_LEFTCTRL},
-                                           {"opt", KEY_LEFTMETA, "opt", KEY_LEFTMETA},
-                                           {"alt", KEY_LEFTALT, "alt", KEY_LEFTALT},
-                                           {"z", KEY_Z, "Z", KEY_Z},
-                                           {"x", KEY_X, "X", KEY_X},
-                                           {"c", KEY_C, "C", KEY_C},
-                                           {"v", KEY_V, "V", KEY_V},
-                                           {"b", KEY_B, "B", KEY_B},
-                                           {"n", KEY_N, "N", KEY_N},
-                                           {"m", KEY_M, "M", KEY_M},
-                                           {",", KEY_COMMA, "<", KEY_COMMA},
-                                           {".", KEY_DOT, ">", KEY_DOT},
-                                           {"/", KEY_SLASH, "?", KEY_SLASH},
-                                           {" ", KEY_SPACE, " ", KEY_SPACE}}};
+// clang-format off
+const KeyValue_t _key_value_map[4][14] = {
+    // Row 0
+    {{"`",     KEY_GRAVE,      "~",     KEY_GRAVE,      "esc",   KEY_ESC,       0              },
+     {"1",     KEY_1,          "!",     KEY_1,          nullptr, KEY_NONE,      0              },
+     {"2",     KEY_2,          "@",     KEY_2,          nullptr, KEY_NONE,      0              },
+     {"3",     KEY_3,          "#",     KEY_3,          nullptr, KEY_NONE,      0              },
+     {"4",     KEY_4,          "$",     KEY_4,          nullptr, KEY_NONE,      0              },
+     {"5",     KEY_5,          "%",     KEY_5,          nullptr, KEY_NONE,      0              },
+     {"6",     KEY_6,          "^",     KEY_6,          nullptr, KEY_NONE,      0              },
+     {"7",     KEY_7,          "&",     KEY_7,          nullptr, KEY_NONE,      0              },
+     {"8",     KEY_8,          "*",     KEY_8,          nullptr, KEY_NONE,      0              },
+     {"9",     KEY_9,          "(",     KEY_9,          nullptr, KEY_NONE,      0              },
+     {"0",     KEY_0,          ")",     KEY_0,          nullptr, KEY_NONE,      0              },
+     {"-",     KEY_MINUS,      "_",     KEY_MINUS,      nullptr, KEY_NONE,      0              },
+     {"=",     KEY_EQUAL,      "+",     KEY_EQUAL,      nullptr, KEY_NONE,      0              },
+     {"del",   KEY_BACKSPACE,  "del",   KEY_BACKSPACE,  "del",   KEY_DELETE,    0              }},
+    // Row 1
+    {{"tab",   KEY_TAB,        "tab",   KEY_TAB,        nullptr, KEY_NONE,      0              },
+     {"q",     KEY_Q,          "Q",     KEY_Q,          "Q",     KEY_Q,         KEY_MOD_LSHIFT },
+     {"w",     KEY_W,          "W",     KEY_W,          "W",     KEY_W,         KEY_MOD_LSHIFT },
+     {"e",     KEY_E,          "E",     KEY_E,          "E",     KEY_E,         KEY_MOD_LSHIFT },
+     {"r",     KEY_R,          "R",     KEY_R,          "R",     KEY_R,         KEY_MOD_LSHIFT },
+     {"t",     KEY_T,          "T",     KEY_T,          "T",     KEY_T,         KEY_MOD_LSHIFT },
+     {"y",     KEY_Y,          "Y",     KEY_Y,          "Y",     KEY_Y,         KEY_MOD_LSHIFT },
+     {"u",     KEY_U,          "U",     KEY_U,          "U",     KEY_U,         KEY_MOD_LSHIFT },
+     {"i",     KEY_I,          "I",     KEY_I,          "I",     KEY_I,         KEY_MOD_LSHIFT },
+     {"o",     KEY_O,          "O",     KEY_O,          "O",     KEY_O,         KEY_MOD_LSHIFT },
+     {"p",     KEY_P,          "P",     KEY_P,          "P",     KEY_P,         KEY_MOD_LSHIFT },
+     {"[",     KEY_LEFTBRACE,  "{",     KEY_LEFTBRACE,  nullptr, KEY_NONE,      0              },
+     {"]",     KEY_RIGHTBRACE, "}",     KEY_RIGHTBRACE, nullptr, KEY_NONE,      0              },
+     {"\\",    KEY_BACKSLASH,  "|",     KEY_BACKSLASH,  nullptr, KEY_NONE,      0              }},
+    // Row 2
+    {{"fn",    KEY_NONE,       "fn",    KEY_NONE,       nullptr, KEY_NONE,      0              },
+     {"shift", KEY_LEFTSHIFT,  "shift", KEY_LEFTSHIFT,  nullptr, KEY_NONE,      0              },
+     {"a",     KEY_A,          "A",     KEY_A,          "A",     KEY_A,         KEY_MOD_LSHIFT },
+     {"s",     KEY_S,          "S",     KEY_S,          "S",     KEY_S,         KEY_MOD_LSHIFT },
+     {"d",     KEY_D,          "D",     KEY_D,          "D",     KEY_D,         KEY_MOD_LSHIFT },
+     {"f",     KEY_F,          "F",     KEY_F,          "F",     KEY_F,         KEY_MOD_LSHIFT },
+     {"g",     KEY_G,          "G",     KEY_G,          "G",     KEY_G,         KEY_MOD_LSHIFT },
+     {"h",     KEY_H,          "H",     KEY_H,          "H",     KEY_H,         KEY_MOD_LSHIFT },
+     {"j",     KEY_J,          "J",     KEY_J,          "J",     KEY_J,         KEY_MOD_LSHIFT },
+     {"k",     KEY_K,          "K",     KEY_K,          "K",     KEY_K,         KEY_MOD_LSHIFT },
+     {"l",     KEY_L,          "L",     KEY_L,          "L",     KEY_L,         KEY_MOD_LSHIFT },
+     {";",     KEY_SEMICOLON,  ":",     KEY_SEMICOLON,  "up",    KEY_UP,        0              },
+     {"'",     KEY_APOSTROPHE, "\"",    KEY_APOSTROPHE, nullptr, KEY_NONE,      0              },
+     {"enter", KEY_ENTER,      "enter", KEY_ENTER,      nullptr, KEY_NONE,      0              }},
+    // Row 3
+    {{"ctrl",  KEY_LEFTCTRL,   "ctrl",  KEY_LEFTCTRL,   nullptr, KEY_NONE,      0              },
+     {"opt",   KEY_LEFTMETA,   "opt",   KEY_LEFTMETA,   nullptr, KEY_NONE,      0              },
+     {"alt",   KEY_LEFTALT,    "alt",   KEY_LEFTALT,    nullptr, KEY_NONE,      0              },
+     {"z",     KEY_Z,          "Z",     KEY_Z,          "Z",     KEY_Z,         KEY_MOD_LSHIFT },
+     {"x",     KEY_X,          "X",     KEY_X,          "X",     KEY_X,         KEY_MOD_LSHIFT },
+     {"c",     KEY_C,          "C",     KEY_C,          "C",     KEY_C,         KEY_MOD_LSHIFT },
+     {"v",     KEY_V,          "V",     KEY_V,          "V",     KEY_V,         KEY_MOD_LSHIFT },
+     {"b",     KEY_B,          "B",     KEY_B,          "B",     KEY_B,         KEY_MOD_LSHIFT },
+     {"n",     KEY_N,          "N",     KEY_N,          "N",     KEY_N,         KEY_MOD_LSHIFT },
+     {"m",     KEY_M,          "M",     KEY_M,          "M",     KEY_M,         KEY_MOD_LSHIFT },
+     {",",     KEY_COMMA,      "<",     KEY_COMMA,      "left",  KEY_LEFT,      0              },
+     {".",     KEY_DOT,        ">",     KEY_DOT,        "down",  KEY_DOWN,      0              },
+     {"/",     KEY_SLASH,      "?",     KEY_SLASH,      "right", KEY_RIGHT,     0              },
+     {" ",     KEY_SPACE,      " ",     KEY_SPACE,      nullptr, KEY_NONE,      0              }}};
+// clang-format on
 
 Keyboard::KeyEvent_t Keyboard::convertToKeyEvent(const KeyEventRaw_t& key)
 {
@@ -209,29 +219,18 @@ Keyboard::KeyEvent_t Keyboard::convertToKeyEvent(const KeyEventRaw_t& key)
         return ret;
     }
 
-    // Fn layer: override selected keys when Fn is held
+    // Fn layer: override selected keys when Fn is held.
+    // Keys with no Fn entry (fnKeyCode == KEY_NONE) fall through to the normal
+    // lookup below, so they behave as if Fn were not held.  To add a new Fn
+    // mapping, only the table needs updating -- no code change required.
     if (_fn_state) {
-        struct FnMap_t {
-            uint8_t row;
-            uint8_t col;
-            KeScanCode_t code;
-            const char* name;
-        };
-        static const FnMap_t fn_map[] = {
-            {0, 0,  KEY_ESC,    "esc"},
-            {0, 13, KEY_DELETE, "del"},
-            {2, 11, KEY_UP,     "up"},
-            {3, 10, KEY_LEFT,   "left"},
-            {3, 11, KEY_DOWN,   "down"},
-            {3, 12, KEY_RIGHT,  "right"},
-        };
-        for (const auto& m : fn_map) {
-            if (key.row == m.row && key.col == m.col) {
-                ret.keyCode    = m.code;
-                ret.keyName    = m.name;
-                ret.isModifier = false;
-                return ret;
-            }
+        const auto& kv = _key_value_map[key.row][key.col];
+        if (kv.fnKeyCode != KEY_NONE) {
+            ret.keyCode        = kv.fnKeyCode;
+            ret.keyName        = kv.fnName;
+            ret.isModifier     = false;
+            ret.extraModifiers = kv.fnExtraModifiers;
+            return ret;
         }
     }
 

--- a/main/hal/keyboard/keyboard.cpp
+++ b/main/hal/keyboard/keyboard.cpp
@@ -130,6 +130,24 @@ void Keyboard::update_modifier_mask(const KeyEventRaw_t& key)
     if (key.row == 2 && key.col == 0) {
         _fn_state = key.state;
     }
+
+    // Check alt key (3, 2)
+    if (key.row == 3 && key.col == 2) {
+        if (key.state) {
+            _modifier_mask |= KEY_MOD_LALT;
+        } else {
+            _modifier_mask &= ~KEY_MOD_LALT;
+        }
+    }
+
+    // Check opt/meta key (3, 1)
+    if (key.row == 3 && key.col == 1) {
+        if (key.state) {
+            _modifier_mask |= KEY_MOD_LMETA;
+        } else {
+            _modifier_mask &= ~KEY_MOD_LMETA;
+        }
+    }
 }
 
 struct KeyValue_t {
@@ -245,7 +263,8 @@ Keyboard::KeyEvent_t Keyboard::convertToKeyEvent(const KeyEventRaw_t& key)
         ret.keyName = _key_value_map[key.row][key.col].firstName;
     }
 
-    ret.isModifier = (ret.keyCode == KEY_LEFTSHIFT || ret.keyCode == KEY_LEFTCTRL);
+    ret.isModifier = (ret.keyCode == KEY_LEFTSHIFT || ret.keyCode == KEY_LEFTCTRL ||
+                      ret.keyCode == KEY_LEFTALT   || ret.keyCode == KEY_LEFTMETA);
 
     return ret;
 }

--- a/main/hal/keyboard/keyboard.cpp
+++ b/main/hal/keyboard/keyboard.cpp
@@ -117,8 +117,8 @@ void Keyboard::update_modifier_mask(const KeyEventRaw_t& key)
         }
     }
 
-    // Check shift key (2, 0)
-    if (key.row == 2 && key.col == 0) {
+    // Check shift key (2, 1) - Aa button
+    if (key.row == 2 && key.col == 1) {
         if (key.state) {
             _modifier_mask |= KEY_MOD_LSHIFT;
         } else {
@@ -126,9 +126,9 @@ void Keyboard::update_modifier_mask(const KeyEventRaw_t& key)
         }
     }
 
-    // Check capslock key (2, 1)
-    if (key.row == 2 && key.col == 1) {
-        _capslock_state = key.state;
+    // Check Fn key (2, 0) - Fn button
+    if (key.row == 2 && key.col == 0) {
+        _fn_state = key.state;
     }
 }
 
@@ -167,8 +167,8 @@ const KeyValue_t _key_value_map[4][14] = {{{"`", KEY_GRAVE, "~", KEY_GRAVE},
                                            {"[", KEY_LEFTBRACE, "{", KEY_LEFTBRACE},
                                            {"]", KEY_RIGHTBRACE, "}", KEY_RIGHTBRACE},
                                            {"\\", KEY_BACKSLASH, "|", KEY_BACKSLASH}},
-                                          {{"shift", KEY_LEFTSHIFT, "shift", KEY_LEFTSHIFT},
-                                           {"capslock", KEY_CAPSLOCK, "capslock", KEY_CAPSLOCK},
+                                          {{"fn", KEY_NONE, "fn", KEY_NONE},
+                                           {"shift", KEY_LEFTSHIFT, "shift", KEY_LEFTSHIFT},
                                            {"a", KEY_A, "A", KEY_A},
                                            {"s", KEY_S, "S", KEY_S},
                                            {"d", KEY_D, "D", KEY_D},
@@ -199,26 +199,44 @@ const KeyValue_t _key_value_map[4][14] = {{{"`", KEY_GRAVE, "~", KEY_GRAVE},
 Keyboard::KeyEvent_t Keyboard::convertToKeyEvent(const KeyEventRaw_t& key)
 {
     KeyEvent_t ret;
-
     ret.state = key.state;
 
-    // For letters: use shift/caps lock to determine case
-    // For special characters: use shift to determine which symbol
-    bool use_shifted_version = false;
-
-    // Check if this is a letter key (a-z)
-    KeScanCode_t baseKeyCode = _key_value_map[key.row][key.col].firstKeyCode;
-    bool isLetter            = (baseKeyCode >= KEY_A && baseKeyCode <= KEY_Z);
-
-    if (isLetter) {
-        // For letters, use shift OR caps lock
-        use_shifted_version = (_modifier_mask & KEY_MOD_LSHIFT) || _capslock_state || _is_capslock_locked;
-    } else {
-        // For non-letters (numbers, symbols), only use shift
-        use_shifted_version = (_modifier_mask & KEY_MOD_LSHIFT);
+    // Fn key itself - modifier, no keycode
+    if (key.row == 2 && key.col == 0) {
+        ret.keyCode    = KEY_NONE;
+        ret.keyName    = "fn";
+        ret.isModifier = true;
+        return ret;
     }
 
-    // mclog::tagDebug(_tag, "modifier mask: {:08b} {}", _modifier_mask, use_shifted_version);
+    // Fn layer: override selected keys when Fn is held
+    if (_fn_state) {
+        struct FnMap_t {
+            uint8_t row;
+            uint8_t col;
+            KeScanCode_t code;
+            const char* name;
+        };
+        static const FnMap_t fn_map[] = {
+            {0, 0,  KEY_ESC,    "esc"},
+            {0, 13, KEY_DELETE, "del"},
+            {2, 11, KEY_UP,     "up"},
+            {3, 10, KEY_LEFT,   "left"},
+            {3, 11, KEY_DOWN,   "down"},
+            {3, 12, KEY_RIGHT,  "right"},
+        };
+        for (const auto& m : fn_map) {
+            if (key.row == m.row && key.col == m.col) {
+                ret.keyCode    = m.code;
+                ret.keyName    = m.name;
+                ret.isModifier = false;
+                return ret;
+            }
+        }
+    }
+
+    // Normal key lookup - shift determines upper/symbol layer
+    bool use_shifted_version = (_modifier_mask & KEY_MOD_LSHIFT);
 
     if (use_shifted_version) {
         ret.keyCode = _key_value_map[key.row][key.col].secondKeyCode;
@@ -228,11 +246,7 @@ Keyboard::KeyEvent_t Keyboard::convertToKeyEvent(const KeyEventRaw_t& key)
         ret.keyName = _key_value_map[key.row][key.col].firstName;
     }
 
-    if (ret.keyCode == KEY_LEFTSHIFT || ret.keyCode == KEY_LEFTCTRL || ret.keyCode == KEY_CAPSLOCK) {
-        ret.isModifier = true;
-    } else {
-        ret.isModifier = false;
-    }
+    ret.isModifier = (ret.keyCode == KEY_LEFTSHIFT || ret.keyCode == KEY_LEFTCTRL);
 
     return ret;
 }

--- a/main/hal/keyboard/keyboard.h
+++ b/main/hal/keyboard/keyboard.h
@@ -17,10 +17,12 @@ public:
     };
 
     struct KeyEvent_t {
-        bool state           = false;
-        bool isModifier      = false;
-        KeScanCode_t keyCode = KEY_NONE;
-        const char* keyName  = "";
+        bool state              = false;
+        bool isModifier         = false;
+        KeScanCode_t keyCode    = KEY_NONE;
+        const char* keyName     = "";
+        uint8_t extraModifiers  = 0;  // HID modifier bits to OR into the report in addition to the
+                                      // physical modifier keys (used when Fn injects LSHIFT for A-Z)
     };
 
     mclog::Signal<const KeyEventRaw_t&> onKeyEventRaw;

--- a/main/hal/keyboard/keyboard.h
+++ b/main/hal/keyboard/keyboard.h
@@ -32,14 +32,6 @@ public:
     {
         return _modifier_mask;
     }
-    inline bool isCapsLocked()
-    {
-        return _is_capslock_locked;
-    }
-    inline void setCapsLocked(bool locked)
-    {
-        _is_capslock_locked = locked;
-    }
     inline const KeyEvent_t& getLatestKeyEvent()
     {
         return _key_event_buffer;
@@ -54,8 +46,7 @@ public:
 private:
     Adafruit_TCA8418* _tca8418 = nullptr;
     uint8_t _modifier_mask     = 0;
-    bool _capslock_state       = false;
-    bool _is_capslock_locked   = false;
+    bool _fn_state             = false;
     KeyEventRaw_t _key_event_raw_buffer;
     KeyEvent_t _key_event_buffer;
 

--- a/main/hal/keyboard/keymap.h
+++ b/main/hal/keyboard/keymap.h
@@ -136,8 +136,7 @@ enum KeScanCode_t {
     KEY_INSERT     = 0x49,  // Keyboard Insert
     KEY_HOME       = 0x4a,  // Keyboard Home
     KEY_PAGEUP     = 0x4b,  // Keyboard Page Up
-                            // #define KEY_DELETE 0x4c // Keyboard Delete Forward
-    KEY_DELETE   = 0xD4,    // Keyboard Delete Forward
+    KEY_DELETE   = 0x4c,    // Keyboard Delete Forward
     KEY_END      = 0x4d,    // Keyboard End
     KEY_PAGEDOWN = 0x4e,    // Keyboard Page Down
     KEY_RIGHT    = 0x4f,    // Keyboard Right Arrow


### PR DESCRIPTION
1. Enable Fn key to unlock the Arrow keys. (Important when using the Cardputer as BLE keyboard.)
2. Fix ALT-TAB behaviour (be able to hold ALT while cycling through windows, again important when using as a keyboard).
3. Enable OPT meta key (WIN/SPECIAL): now OPT-L works for screen lock.
4. Fix DEL key (Fn+backspace) to send forward delete.

As mentioned in the commits:
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
