### PR TITLE
misc: Fix a few compiler warnings

### DIFF
--- a/main/apps/app_launcher/app_launcher.h
+++ b/main/apps/app_launcher/app_launcher.h
@@ -45,12 +45,8 @@ private:
     };
 
     struct Data_t {
-        // Menu
-        uint32_t menu_update_preiod = 10;
-        uint32_t menu_update_count  = 0;
-
         // System bar
-        uint32_t system_bar_update_preiod = 1000;
+        uint32_t system_bar_update_period = 1000;
         uint32_t system_bar_update_count  = 0;
         uint32_t bat_update_time_count    = 0;
         SystemState_t system_state;

--- a/main/apps/app_launcher/view/system_bar/system_bar.cpp
+++ b/main/apps/app_launcher/view/system_bar/system_bar.cpp
@@ -25,7 +25,7 @@ void Launcher::start_system_bar()
 
 void Launcher::update_system_bar()
 {
-    if ((GetHAL().millis() - _data.system_bar_update_count) > _data.system_bar_update_preiod) {
+    if ((GetHAL().millis() - _data.system_bar_update_count) > _data.system_bar_update_period) {
         render_system_bar();
         _data.system_bar_update_count = GetHAL().millis();
     }

--- a/main/apps/app_repl/PikaScript/pikascript-core/PikaObj.h
+++ b/main/apps/app_repl/PikaScript/pikascript-core/PikaObj.h
@@ -306,11 +306,13 @@ Arg* arg_setRef(Arg* self, char* name, PikaObj* obj);
 Arg* arg_setObj(Arg* self, char* name, PikaObj* obj);
 
 static inline Arg* arg_newObj(PikaObj* obj) {
-    return arg_setObj(NULL, "", (obj));
+    static char empty[1] = {0};
+    return arg_setObj(NULL, empty, (obj));
 }
 
 static inline Arg* arg_newRef(PikaObj* obj) {
-    return arg_setRef(NULL, "", (obj));
+    static char empty[1] = {0};
+    return arg_setRef(NULL, empty, (obj));
 }
 
 PikaObj* obj_importModuleWithByteCodeFrame(PikaObj* self,

--- a/main/apps/app_repl/PikaScript/pikascript-core/dataArg.h
+++ b/main/apps/app_repl/PikaScript/pikascript-core/dataArg.h
@@ -118,19 +118,23 @@ Arg* arg_setNull(Arg* self);
 Arg* arg_setBytes(Arg* self, char* name, uint8_t* src, size_t size);
 
 static inline Arg* arg_newInt(int64_t val) {
-    return arg_setInt(NULL, "", (val));
+    static char empty[1] = {0};
+    return arg_setInt(NULL, empty, (val));
 }
 
 static inline Arg* arg_newFloat(pika_float val) {
-    return arg_setFloat(NULL, "", (val));
+    static char empty[1] = {0};
+    return arg_setFloat(NULL, empty, (val));
 }
 
 static inline Arg* arg_newPtr(ArgType type, void* pointer) {
-    return arg_setPtr(NULL, "", (type), (pointer));
+    static char empty[1] = {0};
+    return arg_setPtr(NULL, empty, (type), (pointer));
 }
 
 static inline Arg* arg_newStr(char* string) {
-    return arg_setStr(NULL, "", (string));
+    static char empty[1] = {0};
+    return arg_setStr(NULL, empty, (string));
 }
 
 static inline Arg* arg_newNull() {
@@ -138,7 +142,8 @@ static inline Arg* arg_newNull() {
 }
 
 static inline Arg* arg_newBytes(uint8_t* src, size_t size) {
-    return arg_setBytes(NULL, "", (src), (size));
+    static char empty[1] = {0};
+    return arg_setBytes(NULL, empty, (src), (size));
 }
 
 int64_t arg_getInt(Arg* self);

--- a/main/apps/utils/raylib/arkanoid.cpp
+++ b/main/apps/utils/raylib/arkanoid.cpp
@@ -72,10 +72,10 @@ struct ArkanoidData_t {
     bool gameOver = false;
     bool pause    = false;
 
-    Player player                                 = {0};
-    Ball ball                                     = {0};
-    Brick brick[LINES_OF_BRICKS][BRICKS_PER_LINE] = {0};
-    Vector2 brickSize                             = {0};
+    Player player                                 = {};
+    Ball ball                                     = {};
+    Brick brick[LINES_OF_BRICKS][BRICKS_PER_LINE] = {};
+    Vector2 brickSize                             = {};
 
     bool key_left_state  = false;
     bool key_right_state = false;

--- a/main/hal/hal.cpp
+++ b/main/hal/hal.cpp
@@ -726,7 +726,8 @@ void Hal::sd_card_init()
 
     // Options for mounting the filesystem
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {
-        .format_if_mount_failed = false, .max_files = 5, .allocation_unit_size = 16 * 1024};
+        .format_if_mount_failed = false, .max_files = 5, .allocation_unit_size = 16 * 1024,
+        .disk_status_check_enable = false, .use_one_fat = false};
 
     const char mount_point[] = MOUNT_POINT;
     mclog::tagInfo(_tag, "initializing SD card");

--- a/main/hal/utils/tusb_hid_device/tusb_hid_device_helper.c
+++ b/main/hal/utils/tusb_hid_device/tusb_hid_device_helper.c
@@ -100,6 +100,7 @@ typedef enum {
 #define DISTANCE_MAX 125
 #define DELTA_SCALAR 5
 
+#if 0
 static void mouse_draw_square_next_delta(int8_t *delta_x_ret, int8_t *delta_y_ret)
 {
     static mouse_dir_t cur_dir = MOUSE_DIR_RIGHT;
@@ -152,6 +153,7 @@ static void app_send_hid_demo(void)
         vTaskDelay(pdMS_TO_TICKS(20));
     }
 }
+#endif
 
 static void _demo_app_main(void)
 {


### PR DESCRIPTION
- main/apps/app_repl/PikaScript/pikascript-core/PikaObj.h
- main/apps/app_repl/PikaScript/pikascript-core/dataArg.h

  warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]

  (Note that all non-const chars could be an accident waiting to happen.)

- main/apps/utils/raylib/arkanoid.cpp

  warning: missing initializer for member 'Player::size' [-Wmissing-field-initializers]

  (All fields would be set to 0 anyway, but if we set {} in C++ instead of {0} we are explicit that we will accept the default.)

- main/hal/utils/tusb_hid_device/tusb_hid_device_helper.c

  warning: 'app_send_hid_demo' defined but not used [-Wunused-function]

- warning: missing initializer for member 'Player::size' [-Wmissing-field-initializers]

  warning: 'app_send_hid_demo' defined but not used [-Wunused-function]

- main/hal/hal.cpp

  warning: missing initializer for member 'esp_vfs_fat_mount_config_t ... [-Wmissing-field-initializers]