### PR TITLE
time: Prefer UTC timezone over China Standard Time

### DIFF
--- a/main/apps/app_clock/app_clock.cpp
+++ b/main/apps/app_clock/app_clock.cpp
@@ -61,8 +61,8 @@ void AppClock::render_interface()
 
 void AppClock::update_time_display()
 {
-    // Check WiFi connection status instead of SNTP adjustment
-    if (GetHAL().isWifiConnected()) {
+    // We have proper time if we had a WiFi connection
+    if (GetHAL().isTimeSynced()) {
         show_network_time();
     } else {
         show_system_time();

--- a/main/apps/app_launcher/view/system_bar/system_bar.cpp
+++ b/main/apps/app_launcher/view/system_bar/system_bar.cpp
@@ -36,12 +36,17 @@ void Launcher::render_system_bar()
     // Update state
     _data.system_state.wifi_state = GetHAL().isWifiConnected() ? 1 : 4;
 
-    // Time
-    static time_t now;
-    static struct tm timeinfo;
-    time(&now);
-    localtime_r(&now, &timeinfo);
-    _data.system_state.time = fmt::format("{:02d}:{:02d}", timeinfo.tm_hour, timeinfo.tm_min);
+    // Show wall clock once SNTP has synced, otherwise show uptime.
+    if (GetHAL().isTimeSynced()) {
+        static time_t now;
+        static struct tm timeinfo;
+        time(&now);
+        localtime_r(&now, &timeinfo);
+        _data.system_state.time = fmt::format("{:02d}:{:02d} UTC", timeinfo.tm_hour, timeinfo.tm_min);
+    } else {
+        uint32_t mins = GetHAL().millis() / 60000;
+        _data.system_state.time = fmt::format("up {}:{:02d}", mins / 60, mins % 60);
+    }
 
     // Bat
     if ((GetHAL().millis() - _data.bat_update_time_count) > 5000 || _data.bat_update_time_count == 0) {

--- a/main/hal/hal.cpp
+++ b/main/hal/hal.cpp
@@ -363,8 +363,8 @@ void Hal::start_sntp()
         return;
     }
 
-    // Set timezone to UTC+8
-    setenv("TZ", "CST-8", 1);
+    // Set timezone to UTC (we don't know where this device is)
+    setenv("TZ", "UTC0", 1);
     tzset();
 
     esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);

--- a/main/hal/hal.h
+++ b/main/hal/hal.h
@@ -77,6 +77,16 @@ public:
     }
     void wifiDisconnect();
 
+    /* ---------------------------------- Time ---------------------------------- */
+    bool isTimeSynced() const
+    {
+        // Time code in HAL because the clock is technically in hardware. And the
+        // WiFi components set it. Don't check esp_sntp_get_sync_status() because
+        // we're not continuously syncing.
+        constexpr time_t t2026 = 1767225600;  // "2026-01-01T00:00Z"
+        return time(NULL) > t2026;
+    }
+
     /* --------------------------------- EspNow --------------------------------- */
     void espNowInit();
     void espNowDeinit();


### PR DESCRIPTION
Unless we can set the timezone, it's preferable to show UTC time. This change selects the UTC0 timezone (not a typo), and adds "UTC" to the status bar, to clarify to the reader which time is shown.

We can shorten it to "HH:MMZ" if space becomes tight later on.